### PR TITLE
Fix HTML5 audio by pretending to be iOS

### DIFF
--- a/app/src/main/java/com/antest1/kcanotify/h5/GameActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameActivity.java
@@ -87,8 +87,8 @@ public class GameActivity extends XWalkActivity {
     private ProgressBar progressBar1;
 
     // HTML5 audio is bugged in Crosswalk
-    // Use iPhone UA so that Kancolle will fallback to traditional audio playing
-    private final static String USER_AGENT = "Mozilla/5.0 (iPhone) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 Safari/537.36";
+    // Add "edge" to UA so that Kancolle will fallback to traditional audio playing
+    private final static String USER_AGENT = "Mozilla/5.0 (Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 Safari/537.36 Edge/14.14931";
 
     private static final String[] SERVER_IP = new String[]{"203.104.209.71", "203.104.209.87", "125.6.184.215", "203.104.209.183", "203.104.209.150", "203.104.209.134", "203.104.209.167", "203.104.248.135", "125.6.189.7", "125.6.189.39", "125.6.189.71", "125.6.189.103", "125.6.189.135", "125.6.189.167", "125.6.189.215", "125.6.189.247", "203.104.209.23", "203.104.209.39", "203.104.209.55", "203.104.209.102"};
 

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameActivity.java
@@ -85,7 +85,11 @@ public class GameActivity extends XWalkActivity {
     XWalkView mWebview;
     XWalkSettings mWebSettings;
     private ProgressBar progressBar1;
-    private final static String USER_AGENT = "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 Safari/537.36";
+
+    // HTML5 audio is bugged in Crosswalk
+    // Use iPhone UA so that Kancolle will fallback to traditional audio playing
+    private final static String USER_AGENT = "Mozilla/5.0 (iPhone) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 Safari/537.36";
+
     private static final String[] SERVER_IP = new String[]{"203.104.209.71", "203.104.209.87", "125.6.184.215", "203.104.209.183", "203.104.209.150", "203.104.209.134", "203.104.209.167", "203.104.248.135", "125.6.189.7", "125.6.189.39", "125.6.189.71", "125.6.189.103", "125.6.189.135", "125.6.189.167", "125.6.189.215", "125.6.189.247", "203.104.209.23", "203.104.209.39", "203.104.209.55", "203.104.209.102"};
 
     private WebviewBroadcastReceiver webviewBroadcastReceiver = new WebviewBroadcastReceiver();

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameOOIActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameOOIActivity.java
@@ -87,8 +87,8 @@ public class GameOOIActivity extends XWalkActivity {
     private ProgressBar progressBar1;
 
     // HTML5 audio is bugged in Crosswalk
-    // Use iPhone UA so that Kancolle will fallback to traditional audio playing
-    private final static String USER_AGENT = "Mozilla/5.0 (iPhone) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 Safari/537.36";
+    // Add "edge" to UA so that Kancolle will fallback to traditional audio playing
+    private final static String USER_AGENT = "Mozilla/5.0 (Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 Safari/537.36 Edge/14.14931";
 
     private WebviewBroadcastReceiver webviewBroadcastReceiver = new WebviewBroadcastReceiver();
 

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameOOIActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameOOIActivity.java
@@ -85,7 +85,10 @@ public class GameOOIActivity extends XWalkActivity {
     XWalkView mWebview;
     XWalkSettings mWebSettings;
     private ProgressBar progressBar1;
-    private final static String USER_AGENT = "Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 Safari/537.36";
+
+    // HTML5 audio is bugged in Crosswalk
+    // Use iPhone UA so that Kancolle will fallback to traditional audio playing
+    private final static String USER_AGENT = "Mozilla/5.0 (iPhone) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.81 Safari/537.36";
 
     private WebviewBroadcastReceiver webviewBroadcastReceiver = new WebviewBroadcastReceiver();
 


### PR DESCRIPTION
HTML5 audio is buggy in Crosswalk, especially for large and repeatable audio files like BGM.

Kancolle's main.js will not use H5 audio on Edge or iOS. So, change UA is the simplest way to solve the problem.

Either Edge or iPhone/iPad/iPod is okay. However, using iOS UA will affect the DMM page as well. I don't want to rewrite the auto-fill feature for mobile version DMM login, so I use Edge.