### PR TITLE
Rewrite the mouseover simulation for XWalkView

### DIFF
--- a/app/src/main/java/com/antest1/kcanotify/h5/GameActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameActivity.java
@@ -42,6 +42,7 @@ import org.json.JSONObject;
 import org.xwalk.core.JavascriptInterface;
 import org.xwalk.core.XWalkActivity;
 import org.xwalk.core.XWalkCookieManager;
+import org.xwalk.core.XWalkPreferences;
 import org.xwalk.core.XWalkResourceClient;
 import org.xwalk.core.XWalkSettings;
 import org.xwalk.core.XWalkUIClient;
@@ -60,6 +61,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -564,19 +566,27 @@ public class GameActivity extends XWalkActivity {
                                     respByte = serverResponse.bytes();
                                 }
                                 saveFile(path, respByte);
+
+                                // Inject code after caching, so it wont require re-downloading main.js after switching touch mode
+                                if(changeTouchEventPrefs && path.contains("/kcs2/js/main.js")) {
+                                    respByte = injectTouchLogic(respByte);
+                                }
                                 return backToWebView(path, String.valueOf(respByte.length), new ByteArrayInputStream(respByte), this);
                             } else {
                                 return null;
                             }
                         }
                         if (tmp.exists()) {
-
                             Log.d("KCVA", "Local cache uri：：" + uri);
                             //从缓存直接返回客户端，不请求服务器
                             byte[] fileContent = readFileToBytes(tmp);
                             if(path.contains("/gadget_html5/js/kcs_inspection.js")){
                                 String newRespStr = new String(fileContent, "utf-8") + "window.onload=function(){document.body.style.background=\"#000\";document.getElementById(\"spacing_top\").style.height=\"0px\";};";
                                 fileContent = newRespStr.getBytes("utf-8");
+                            }
+                            // Inject code after caching, so it wont require re-downloading main.js after switching touch mode
+                            if(changeTouchEventPrefs && path.contains("/kcs2/js/main.js")) {
+                                fileContent = injectTouchLogic(fileContent);
                             }
                             return backToWebView(path, String.valueOf(fileContent.length), new ByteArrayInputStream(fileContent), this);
                         } else {
@@ -593,13 +603,16 @@ public class GameActivity extends XWalkActivity {
                                     respByte = serverResponse.bytes();
                                 }
                                 saveFile(path, respByte);
+
+                                // Inject code after caching, so it wont require re-downloading main.js after switching touch mode
+                                if(changeTouchEventPrefs && path.contains("/kcs2/js/main.js")) {
+                                    respByte = injectTouchLogic(respByte);
+                                }
                                 return backToWebView(path, String.valueOf(respByte.length), new ByteArrayInputStream(respByte), this);
                             } else {
                                 return null;
                             }
-
                         }
-
                     } catch (Exception e) {
                         e.printStackTrace();
 
@@ -631,7 +644,6 @@ public class GameActivity extends XWalkActivity {
                 }
             }
         },"androidJs");
-
 
         if(chatService) {
             dialogUtils = new ChatDialogUtils(this, new ChatListener() {
@@ -737,7 +749,8 @@ public class GameActivity extends XWalkActivity {
         mWebSettings.setJavaScriptEnabled(true);
         mWebSettings.setMediaPlaybackRequiresUserGesture(false);
 
-//        XWalkView.setWebContentsDebuggingEnabled(true);
+//        XWalkPreferences.setValue(XWalkPreferences.REMOTE_DEBUGGING, true);
+
         mWebview.loadUrl("http://www.dmm.com/netgame/social/-/gadgets/=/app_id=854854/");
 
         mWebview.resumeTimers();
@@ -870,6 +883,7 @@ public class GameActivity extends XWalkActivity {
 
     }
 
+
     @Override
     public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
@@ -908,33 +922,77 @@ public class GameActivity extends XWalkActivity {
             mWebview.setLayoutParams(params);
         }
     }
+
     boolean changeTouchEvent = false;
-    public boolean dispatchTouchEvent(MotionEvent event) {
-        Log.d("touchEvent", event.getToolType(0) + ":" + event.getActionMasked());
-        if(event.getToolType(0) == MotionEvent.TOOL_TYPE_FINGER && changeTouchEventPrefs) {
-            if(event.getAction() == MotionEvent.ACTION_MOVE) {
-                buildMoveEvent(event);
-            } else if(event.getAction() == MotionEvent.ACTION_DOWN && changeTouchEvent){
-                buildMoveEvent(event);
-            } else if(event.getAction() == MotionEvent.ACTION_UP && changeTouchEvent){
-                buildMoveEvent(event);
-            }
-        }
-        return super.dispatchTouchEvent(event);
-    }
+
+    private byte[] injectTouchLogic(byte[] mainJs){
+        // Convert byte[] to String
+        String s = new String(mainJs, StandardCharsets.UTF_8);
 
 
-    private void buildMoveEvent(MotionEvent event){
-        MotionEvent.PointerProperties[] pointerProperties = new MotionEvent.PointerProperties[]{new MotionEvent.PointerProperties()};
-        event.getPointerProperties(0, pointerProperties[0]);
-        MotionEvent.PointerCoords[] pointerCoords = new MotionEvent.PointerCoords[]{new MotionEvent.PointerCoords()};
-        event.getPointerCoords(0, pointerCoords[0]);
-        pointerProperties[0].toolType = MotionEvent.TOOL_TYPE_MOUSE;
-        pointerCoords[0].x -= mWebview.getX();
-        pointerCoords[0].y -= mWebview.getY();
-        long touchTime = SystemClock.uptimeMillis();
-        this.mWebview.onTouchEvent(MotionEvent.obtain(touchTime, touchTime, MotionEvent.ACTION_MOVE, 1, pointerProperties, pointerCoords, 0, 0, 0f, 0f, InputDevice.KEYBOARD_TYPE_NON_ALPHABETIC, 0, InputDevice.SOURCE_TOUCHSCREEN, 0));
+        // Replace the mouseout and mouseover event name to custom name
+        s = s.replace("over:n.pointer?\"pointerover\":\"mouseover\"", "over:\"touchover\"");
+        s = s.replace("out:n.pointer?\"pointerout\":\"mouseout\"", "out:\"touchout\"");
 
+        // Add code patch inspired by https://github.com/pixijs/pixi.js/issues/616
+        s +=    "function patchInteractionManager () {\n" +
+                "  var proto = PIXI.interaction.InteractionManager.prototype;\n" +
+                "\n" +
+                "  function extendMethod (method, extFn) {\n" +
+                "      var old = proto[method];\n" +
+                "      proto[method] = function () {\n" +
+                "          old.call(this, ...arguments);\n" +
+                "          extFn.call(this, ...arguments);\n" +
+                "      };\n" +
+                "  }\n" +
+                "\n" +
+                "  extendMethod('onTouchMove', function () {\n" +
+                "      this.didMove = true;\n" +
+                "  });\n" +
+                "\n" +
+                "  proto.update = mobileUpdate;\n" +
+                "\n" +
+                "  function mobileUpdate(deltaTime) {\n" +
+                "    this._deltaTime += deltaTime;\n" +
+                "    if (this._deltaTime < this.interactionFrequency) {\n" +
+                "        return;\n" +
+                "    }\n" +
+                "    this._deltaTime = 0;\n" +
+                "    if (!this.interactionDOMElement) {\n" +
+                "        return;\n" +
+                "    }\n" +
+                "    if(this.didMove) {\n" +
+                "        this.didMove = false;\n" +
+                "        return;\n" +
+                "    }\n" +
+                "    if (this.eventData.data) {\n" +
+                "      window.__eventData = this.eventData;\n" +
+                "      this.processInteractive(this.eventData, this.renderer._lastObjectRendered, this.processTouchOverOut, true);\n" +
+                "    }\n" +
+                "  }\n" +
+                "\n" +
+                "  extendMethod('processTouchMove', function(displayObject, hit) {\n" +
+                "      this.processTouchOverOut('processTouchMove', displayObject, hit);\n" +
+                "  });\n" +
+                "\n" +
+                "  proto.processTouchOverOut = function (interactionEvent, displayObject, hit) {\n" +
+                "    if(hit) {\n" +
+                "        if(!displayObject._over) {\n" +
+                "            displayObject._over = true;\n" +
+                "            proto.dispatchEvent( displayObject, 'touchover', window.__eventData);\n" +
+                "        }\n" +
+                "    } else {\n" +
+                "        if(displayObject._over) {\n" +
+                "            displayObject._over = false;\n" +
+                "            proto.dispatchEvent( displayObject, 'touchout', window.__eventData);\n" +
+                "        }\n" +
+                "    }\n" +
+                "  };\n" +
+                "}\n" +
+                "patchInteractionManager();";
+
+        // Convert back to bytes
+        return s.getBytes();
     }
 
     @Override


### PR DESCRIPTION
Old method of simulation (dispatching mouse events to Webview directly inside the app) does not work on XWalkView (Chromium 53) because native mouse support on Android is a Chromium 58 feature.

The new simulation logic is done using JavaScript. It extended the Pixi.js to emit custom touch events. And I patch the game (main.js) to let the UI components listen to **touchover** and **touchout** instead of **mouseover** and **mouseout**.

### Reminder
1. The new simulation is active throughout the game. No exception for port page. The big buttons in the port UI will be a bit difficult to click.
2. Please maintain code quality after bug fixes. Duplicating code in 4 similar activity classes is unacceptable.