### PR TITLE
Fix ultimate frame rate issue

### DIFF
--- a/app/src/main/java/com/antest1/kcanotify/h5/GameActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameActivity.java
@@ -149,6 +149,12 @@ public class GameActivity extends GameBaseActivity {
             }
         },"androidJs");
 
+        mWebview.addJavascriptInterface(new Object(){
+            @JavascriptInterface
+            public void update(String newFps) {
+                updateFpsCounter(newFps);
+            }
+        },"fpsUpdater");
     }
 
     @Override

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameActivity.java
@@ -182,7 +182,7 @@ public class GameActivity extends GameBaseActivity {
         mWebSettings = mWebview.getSettings();
         mWebSettings.setUserAgentString(USER_AGENT);
         mWebSettings.setBuiltInZoomControls(true);
-        mWebSettings.setCacheMode(XWalkSettings.LOAD_DEFAULT);
+        mWebSettings.setCacheMode(XWalkSettings.LOAD_NO_CACHE);
 /*        Properties prop = System.getProperties();
         prop.setProperty("proxySet", "true");
         prop.setProperty("proxyHost", "218.241.131.227");

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameBaseActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameBaseActivity.java
@@ -999,7 +999,7 @@ public abstract class GameBaseActivity extends XWalkActivity {
                 "      times.shift();\n" +
                 "    }\n" +
                 "    times.push(now);\n" +
-                "    window.fpsUpdater.update(createjs.Ticker.getMeasuredFPS());\n" +
+                "    window.fpsUpdater.update(times.length);\n" +
                 "    refreshLoop();\n" +
                 "  });\n" +
                 "}\n" +

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameBaseActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameBaseActivity.java
@@ -641,6 +641,7 @@ public abstract class GameBaseActivity extends XWalkActivity {
                     // Inject code after caching, so it wont require re-downloading main.js after switching touch mode
                     if(path.contains("/kcs2/js/main.js")) {
                         fileContent = injectFpsUpdater(fileContent);
+                        fileContent = injectTickerTimingMode(fileContent);
                         if (changeTouchEventPrefs && changeWebview) {
                             fileContent = injectTouchLogic(fileContent);
                         }
@@ -665,6 +666,7 @@ public abstract class GameBaseActivity extends XWalkActivity {
                         // Inject code after caching, so it wont require re-downloading main.js after switching touch mode
                         if(path.contains("/kcs2/js/main.js")) {
                             respByte = injectFpsUpdater(respByte);
+                            respByte = injectTickerTimingMode(respByte);
                             if (changeTouchEventPrefs && changeWebview) {
                                 respByte = injectTouchLogic(respByte);
                             }
@@ -979,7 +981,6 @@ public abstract class GameBaseActivity extends XWalkActivity {
         return s.getBytes();
     }
 
-
     private byte[] injectFpsUpdater(byte[] mainJs){
         // Convert byte[] to String
         String s = new String(mainJs, StandardCharsets.UTF_8);
@@ -998,12 +999,23 @@ public abstract class GameBaseActivity extends XWalkActivity {
                 "      times.shift();\n" +
                 "    }\n" +
                 "    times.push(now);\n" +
-                "    window.fpsUpdater.update(times.length);\n" +
+                "    window.fpsUpdater.update(createjs.Ticker.getMeasuredFPS());\n" +
                 "    refreshLoop();\n" +
                 "  });\n" +
                 "}\n" +
                 "\n" +
                 "refreshLoop();";
+
+        // Convert back to bytes
+        return s.getBytes();
+    }
+
+    private byte[] injectTickerTimingMode(byte[] mainJs){
+        // Convert byte[] to String
+        String s = new String(mainJs, StandardCharsets.UTF_8);
+
+        // Replace the ticker timing mode to keep animation smooth even with a lot of events (i.e. touch taps)
+        s = s.replace("createjs.Ticker.TIMEOUT", "createjs.Ticker.RAF");
 
         // Convert back to bytes
         return s.getBytes();

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameBaseActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameBaseActivity.java
@@ -177,7 +177,7 @@ public abstract class GameBaseActivity extends XWalkActivity {
             Log.e("KCAV", "onCreate: " + "native hook result-->" + (nativeInit(Build.VERSION.SDK_INT, proxyEnable, proxyIP) == 0));
         }
 
-        changeWebview = prefs.getBoolean("change_webview", true);
+        changeWebview = prefs.getBoolean("change_webview", false);
         if(changeWebview) {
             setContentView(R.layout.activity_game_webview);
         } else {

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameOOIActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameOOIActivity.java
@@ -114,6 +114,13 @@ public class GameOOIActivity extends GameBaseActivity {
                 jsToJava(requestUrl, param, respData);
             }
         },"androidJs");
+
+        mWebview.addJavascriptInterface(new Object(){
+            @JavascriptInterface
+            public void update(String newFps) {
+                updateFpsCounter(newFps);
+            }
+        },"fpsUpdater");
     }
 
     public void loginExpire(String requestUrl, String respData){

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameOOIActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameOOIActivity.java
@@ -170,7 +170,7 @@ public class GameOOIActivity extends GameBaseActivity {
         mWebSettings = mWebview.getSettings();
         mWebSettings.setUserAgentString(USER_AGENT);
         mWebSettings.setBuiltInZoomControls(true);
-        mWebSettings.setCacheMode(XWalkSettings.LOAD_DEFAULT);
+        mWebSettings.setCacheMode(XWalkSettings.LOAD_NO_CACHE);
 /*        Properties prop = System.getProperties();
         prop.setProperty("proxySet", "true");
         prop.setProperty("proxyHost", "218.241.131.227");

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameOOIWebViewActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameOOIWebViewActivity.java
@@ -162,6 +162,13 @@ public class GameOOIWebViewActivity extends GameBaseActivity {
             }
         },"androidJs");
 
+        mWebview.addJavascriptInterface(new Object(){
+            @JavascriptInterface
+            public void update(String newFps) {
+                updateFpsCounter(newFps);
+            }
+        },"fpsUpdater");
+
         mWebview.loadUrl("http://" + hostName + "/poi");
     }
 

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameOOIWebViewActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameOOIWebViewActivity.java
@@ -68,7 +68,7 @@ public class GameOOIWebViewActivity extends GameBaseActivity {
         mWebSettings = mWebview.getSettings();
         mWebSettings.setUserAgentString(USER_AGENT);
         mWebSettings.setBuiltInZoomControls(true);
-        mWebSettings.setCacheMode(WebSettings.LOAD_DEFAULT);
+        mWebSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
         // 设置与Js交互的权限
         mWebSettings.setJavaScriptEnabled(true);
         mWebSettings.setMediaPlaybackRequiresUserGesture(false);

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameWebViewActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameWebViewActivity.java
@@ -68,7 +68,7 @@ public class GameWebViewActivity extends GameBaseActivity {
         mWebSettings = mWebview.getSettings();
         mWebSettings.setUserAgentString(USER_AGENT);
         mWebSettings.setBuiltInZoomControls(true);
-        mWebSettings.setCacheMode(WebSettings.LOAD_DEFAULT);
+        mWebSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
         // 设置与Js交互的权限
         mWebSettings.setJavaScriptEnabled(true);
         mWebSettings.setMediaPlaybackRequiresUserGesture(false);

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameWebViewActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameWebViewActivity.java
@@ -171,6 +171,13 @@ public class GameWebViewActivity extends GameBaseActivity {
             }
         },"androidJs");
 
+        mWebview.addJavascriptInterface(new Object(){
+            @JavascriptInterface
+            public void update(String newFps) {
+                updateFpsCounter(newFps);
+            }
+        },"fpsUpdater");
+
         mWebview.loadUrl("http://www.dmm.com/netgame/social/-/gadgets/=/app_id=854854/");
     }
 

--- a/app/src/main/java/com/antest1/kcanotify/h5/MainActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/MainActivity.java
@@ -189,19 +189,23 @@ public class MainActivity extends AppCompatActivity {
                 }*/
                 SharedPreferences prefs = getSharedPreferences("pref", Context.MODE_PRIVATE);
                 String gamePageType = prefs.getString("game_page_type", "0");
-                boolean changeWebview = prefs.getBoolean("change_webview", false);
+                boolean changeWebview = prefs.getBoolean("change_webview", true);
                 if(gamePageType.equals("0")) {
-                    Intent intent = new Intent(MainActivity.this, GameWebViewActivity.class);
+                    Intent intent;
                     if(changeWebview){
                         intent = new Intent(MainActivity.this, GameActivity.class);
+                    } else {
+                        intent = new Intent(MainActivity.this, GameWebViewActivity.class);
                     }
                     intent.putExtra("imageSize", imageSize);
                     startActivity(intent);
                     MainActivity.this.finish();
                 } else {
-                    Intent intent = new Intent(MainActivity.this, GameOOIWebViewActivity.class);
+                    Intent intent;
                     if(changeWebview){
                         intent = new Intent(MainActivity.this, GameOOIActivity.class);
+                    } else {
+                        intent = new Intent(MainActivity.this, GameOOIWebViewActivity.class);
                     }
                     intent.putExtra("imageSize", imageSize);
                     startActivity(intent);
@@ -296,11 +300,11 @@ public class MainActivity extends AppCompatActivity {
                 if (response != null && !KcaApplication.isCheckVersion && System.currentTimeMillis() - KcaApplication.checkVersionDate > 24 * 60 * 60 * 1000) {
                     KcaApplication.isCheckVersion = true;
                     KcaApplication.checkVersionDate = System.currentTimeMillis();
-                        final JsonObject response_data = new JsonParser().parse(response).getAsJsonObject();
-                        if(response_data.has("imageSize")){
-                            imageSize = response_data.get("imageSize").getAsString();
-                        }
-                        handler.post(() -> {
+                    final JsonObject response_data = new JsonParser().parse(response).getAsJsonObject();
+                    if(response_data.has("imageSize")){
+                        imageSize = response_data.get("imageSize").getAsString();
+                    }
+                    handler.post(() -> {
                         UpdateAppUtils.from(this)
                                 .checkBy(UpdateAppUtils.CHECK_BY_VERSION_NAME) //更新检测方式，默认为VersionCode
                                 .serverVersionCode(2641)

--- a/app/src/main/java/com/antest1/kcanotify/h5/MainActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/MainActivity.java
@@ -189,7 +189,7 @@ public class MainActivity extends AppCompatActivity {
                 }*/
                 SharedPreferences prefs = getSharedPreferences("pref", Context.MODE_PRIVATE);
                 String gamePageType = prefs.getString("game_page_type", "0");
-                boolean changeWebview = prefs.getBoolean("change_webview", true);
+                boolean changeWebview = prefs.getBoolean("change_webview", false);
                 if(gamePageType.equals("0")) {
                     Intent intent;
                     if(changeWebview){

--- a/app/src/main/res/layout/activity_game_webview.xml
+++ b/app/src/main/res/layout/activity_game_webview.xml
@@ -36,7 +36,20 @@
         android:progressBackgroundTint="@android:color/white"
         android:progressTint="#00ff00"
         android:visibility="gone" />
-
+    <TextView
+        android:id="@+id/fps_counter"
+        style="@android:style/Widget.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:progressBackgroundTint="@android:color/white"
+        android:progressTint="#00ff00"
+        android:padding="8dp"
+        android:text=""
+        android:textColor="#ffff00"
+        android:textSize="20sp"
+        android:gravity="right"
+        android:textAlignment="gravity"
+        />
     <com.antest1.kcanotify.h5.StrokeTextView
         android:id="@+id/subtitle_textview_stroke"
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_game_webview_ori.xml
+++ b/app/src/main/res/layout/activity_game_webview_ori.xml
@@ -36,7 +36,20 @@
         android:progressBackgroundTint="@android:color/white"
         android:progressTint="#00ff00"
         android:visibility="gone" />
-
+    <TextView
+        android:id="@+id/fps_counter"
+        style="@android:style/Widget.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:progressBackgroundTint="@android:color/white"
+        android:progressTint="#00ff00"
+        android:padding="8dp"
+        android:text=""
+        android:textColor="#ffff00"
+        android:textSize="20sp"
+        android:gravity="right"
+        android:textAlignment="gravity"
+        />
     <com.antest1.kcanotify.h5.StrokeTextView
         android:id="@+id/subtitle_textview_stroke"
         android:layout_width="match_parent"


### PR DESCRIPTION
### FPS counter
Added FPS counter to display FPS on the top right hand corner (always on)

### 60fps everywhere
Finally figured out the issues of low frame rate. The fix works on any version of WebView, and it also keeps crosswalk smooth when user taps.

### Crosswalk phase out
As the frame rate issue is solved in WebView. There is no point to include XWalkView anymore. It is no longer the default option now. Please consider removing it in the future as it has other minor bugs.

### Fix crash
Fix a crash caused by wrong WebView choice default value (first "Game Start" after new installation was affected)

### Disable WebView level resource caching
As there is already a custom caching system. It should not be handled one more time by the browser control.