### PR TITLE
[Experimental] Rewrite caching system, boost performance, and solve GPU OOM issue

### DIFF
--- a/app/src/main/assets/xwalk-command-line
+++ b/app/src/main/assets/xwalk-command-line
@@ -1,0 +1,1 @@
+xwalk  --force-gpu-rasterization --webgl-antialiasing-mode=none --js-flags="--optimize_for_size=true --always_compact=true"

--- a/app/src/main/assets/xwalk-command-line
+++ b/app/src/main/assets/xwalk-command-line
@@ -1,1 +1,1 @@
-xwalk  --force-gpu-rasterization --webgl-antialiasing-mode=none --js-flags="--optimize_for_size=true --always_compact=true"
+xwalk  --force-gpu-rasterization --webgl-antialiasing-mode=none --js-flags="--always_compact=true"

--- a/app/src/main/java/com/antest1/kcanotify/h5/GameBaseActivity.java
+++ b/app/src/main/java/com/antest1/kcanotify/h5/GameBaseActivity.java
@@ -1136,7 +1136,7 @@ public abstract class GameBaseActivity extends XWalkActivity {
         // Load the full image in an img object instead of a BaseTexture resource, so it does not loaded into GPU
         pixi = pixi.replace("this.add(r,s,o,function(r){if(r.error)return void e(r.error);var n=new a.Spritesheet(r.texture.baseTexture,t.data,t.url);n.parse(function(){t.spritesheet=n,t.textures=n.textures,e()})})",
                 "var image=new Image();" +
-                        "image.onerror=function(){next(new Error('Fail to download image: '+image.src))};" +
+                        "image.onerror=function(){next(new Error('Fail to download image: '+image.src))};" + // TODO: retry downloading the image for a few times
                         "image.onload=function(){" +
                           "var n=new a.Spritesheet(null,t.data,t.url);" +
                           "n.image=image;" +
@@ -1160,7 +1160,7 @@ public abstract class GameBaseActivity extends XWalkActivity {
                         "tmpCanvas.getContext('2d').drawImage(this.image, u.x, u.y, u.w, u.h, 0, 0, u.w, u.h);" +
                         "var bt = new PIXI.BaseTexture(tmpCanvas);" +
                         "this.textures[s]=new o.Texture(bt,h,d,l,a.rotated?2:0,a.anchor),o.Texture.addToCache(this.textures[s],s)}r++};" +
-                        "this.image.onload=null,this.image.onerror=null,this.image.url=null,this.image=null" + // Also destroy the baseTexture after the loop
+                        "this.image.onload=null,this.image.onerror=null,this.image=null" + // Also destroy the baseTexture after the loop
                         "},");
 
         // As the shared baseTexture is already destroyed in the parser,
@@ -1275,6 +1275,11 @@ public abstract class GameBaseActivity extends XWalkActivity {
 
         // Replace the ticker timing mode to keep animation smooth even with a lot of events (i.e. touch taps)
         s = s.replace("createjs.Ticker.TIMEOUT", "createjs.Ticker.RAF");
+
+        s = s.replace("GC_MAX_CHECK_COUNT=180", "GC_MAX_CHECK_COUNT=180");
+        s = s.replace("PIXI.settings.GC_MAX_IDLE=360", "" +
+            "PIXI.settings.GC_MAX_IDLE=360," +
+            "PIXI.settings.MIPMAP_TEXTURES=false"); // Save mem if an image is power of 2
 
         // Convert back to bytes
         return s.getBytes();


### PR DESCRIPTION
to be documented within a day...

- Cache system now writes cache file while downloading
  - Instead of start writing file after download completed

- BufferedOutputStream buffer increases size to 4KB
  - Instead of default 512B which is too small for a block

- Shouldinterceptrequest() now returns a response immediately when a resource cache is missing
  - Instead of return a response after download completed and cache file written
  - Reduces lagging in crosswalk and old webview because shouldinterceptrequest() is single threaded and blocks UI. Return a fake header so it won't freeze screen until resource downloaded
  - No improvement in new webview (77+?) because shouldinterceptrequest() is already multi threaded
  - As we immediate return a fake header, the real download process is offloaded to the thread who calls read() of the returned inputsteam. The resource reading thread is multi threaded and does not block UI in both crosswalk and webview(all versions) 

- Internet error handling is different now
  - As we already returned a fake success header to webview/crosswalk, no way to indicate that we failed to download a network resource once the inputstream starts reading
  - Stream is ended if there is a network error, meaning game client will receive an empty file
  - Game will gets error and hangs if a sprite json fails to download. If a png or mp3 fails, game continues with missing content (transparent sptires, no sound, etc.)

- Use a flag for V8 in crosswalk to compact memory after each GC
  - In theory, it should reduces the chance of OOM crashing if chromium fails to allocate mem for a huge image as memory space is too fragmented
  - Seems to crash the chromium when locking screen? Need more testing

- Also some more 玄學 flags for crosswalk to improve performance